### PR TITLE
支持将apk直接拖入批处理命令进行签名

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 |keyAlias|别名|
 |aliasPassword|别名密码|
 ## 3.使用bat启动
-将以下命令放置在一个bat文件中即可。其中 **-configFilePath** 后面接着的是上面的配置文件的地址。 可以将bat文件添加到桌面会计方式，然后将要签名的apk拖到该快捷方式上就可以直接进行签名
+将以下命令放置在一个bat文件中即可。其中 **-configFilePath** 后面接着的是上面的配置文件的地址。 可以将bat文件添加到桌面快捷方式，然后将要签名的apk拖到该快捷方式上就可以直接进行签名
 ```java
 start /min "cmd" java -jar autoSign-1.0.jar -configFilePath .\signConfig.json -apkFilePath %1
 ```

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@
 |keyAlias|别名|
 |aliasPassword|别名密码|
 ## 3.使用bat启动
-将以下命令放置在一个bat文件中。即可。其中 **-configFilePath** 后面接着的是上面的配置文件的地址。
+将以下命令放置在一个bat文件中即可。其中 **-configFilePath** 后面接着的是上面的配置文件的地址。 可以将bat文件添加到桌面会计方式，然后将要签名的apk拖到该快捷方式上就可以直接进行签名
 ```java
-start /min "cmd" java -jar autoSign-1.0.jar -configFilePath .\signConfig.json
+start /min "cmd" java -jar autoSign-1.0.jar -configFilePath .\signConfig.json -apkFilePath %1
 ```
 ## 直接拖入
 拖入apk以后会自动解析出包名，然后通过配置文件签名。最后在apk原来的位置生成一个名字为 xxx-signed.apk

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -38,7 +38,11 @@ public class Main {
             doSign(log,str, finalSignConfigFile);
             return null;
         });
-
+        // 如果apk路径不为空直接进行签名
+        String apkPath=getApkPathFromArgs(args);
+        if(!isEmpty(apkPath)){
+            doSign(log,apkPath, finalSignConfigFile);
+        }
     }
 
     private static void doSign(Log log, String apkPath, SignConfigFile configFile) {
@@ -100,6 +104,27 @@ public class Main {
         String configFilePath=null;
         for(int i=0;i<args.length;i++){
             if(CONFIG_KEY.equals(args[i])&&i<(args.length-1)){
+                configFilePath=args[i+1];
+            }
+        }
+
+        return configFilePath;
+    }
+
+    private static final String APK_PATH_KEY="-apkFilePath";
+
+    /**
+     * 获取apk路径
+     * @param args
+     * @return
+     */
+    private static String getApkPathFromArgs(String[] args) {
+        if(args==null||args.length==0){
+            return null;
+        }
+        String configFilePath=null;
+        for(int i=0;i<args.length;i++){
+            if(APK_PATH_KEY.equals(args[i])&&i<(args.length-1)){
                 configFilePath=args[i+1];
             }
         }

--- a/src/main/java/org/example/config/SignConfigFile.java
+++ b/src/main/java/org/example/config/SignConfigFile.java
@@ -35,20 +35,26 @@ public class SignConfigFile implements Serializable {
     }
 
     /**
-     * signToolsPath : D:\Android\SDKuild-tools\33.0.2\apksigner.bat
+     * signToolsPath : D:\Android\SDK\build-tools\33.0.2\apksigner.bat
+     * zipalignToolsPath : D:\Android\SDK\build-tools\33.0.2\zipalign.exe
      * signConfigs : [{"appId":"com.wznews.news.app","path":"E:\\Desktop\\apk\\keysotres\\wzrb.jks","storePassword":"monsoon","keyAlias":"myandroidkey","aliasPassword":"monsoon"}]
      */
 
     private String signToolsPath;
+    private String zipalignToolsPath;
     private List<SignConfigsBean> signConfigs;
 
     private String getSignToolsPath() {
         return signToolsPath;
     }
 
+    public String getZipalignToolsPath() {
+        return zipalignToolsPath;
+    }
 
-
-
+    public void setZipalignToolsPath(String zipalignToolsPath) {
+        this.zipalignToolsPath = zipalignToolsPath;
+    }
 
     public SignConfigsBean getConfigBeanByPackageName(String packageName) {
         if(packageName==null||packageName.isEmpty()){
@@ -60,6 +66,7 @@ public class SignConfigFile implements Serializable {
         for(SignConfigsBean bean:signConfigs){
             if(packageName.equals(bean.getAppId())){
                 bean.setSignToolsPath(getSignToolsPath());
+                bean.setZipalignToolsPath(getZipalignToolsPath());
                 return bean;
             }
         }


### PR DESCRIPTION
支持通过-apkFilePath参数获取apk路径，其中%1表示拖入的apk的绝对路径，不过需要注意的是直接拖到文件夹下的bat文件无法使用（除非apk和bat文件在同一个目录），但是添加到桌面快捷方式之后可以直接拖入